### PR TITLE
Fix comparison with NaN in api.js

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -577,7 +577,7 @@ function putRequest (service_log, serviceid, service_command, service_control, v
  * @param  value
  */
 function checkValue60(value) {
-	if (value === NaN) value = 60; // seconds
+	if (isNaN(value)) value = 60; // seconds
 	if (value < 0) value = value * -1; // just make it positive
 	value = value - (value % 60); // make sure that we have multiples of 60 seconds
 	return value;
@@ -1743,7 +1743,7 @@ function setForecastState(name, a, type, propval) {
 	// because history.add returns an empty string in case of error
 	if (typeof propval != 'number') {
 		let n = parseInt(propval);
-		if (n === NaN) {
+		if (isNaN(n)) {
 			ju.adapterloginfo(1, 'setForecastState: NaN: ' + propval + ' / ' + nx);
 			n = -1;
 		}
@@ -2332,7 +2332,7 @@ function checkVal(servicetype, name, val) {
 	
 	if (commontype === 'number') {
 		let n = parseInt(val);
-		if (n === NaN) {
+		if (isNaN(n)) {
 			ju.adapterloginfo(1, 'checkVal: NaN: ' + val + ' / ' + servicetype + ' / ' + name );
 			n = -1;
 		}


### PR DESCRIPTION
Replaced 'value === NaN' with 'isNaN(value)' for correct NaN comparison. The '===' comparison does not work with NaN as per JavaScript's rules. This change ensures the intended behavior.